### PR TITLE
Replace the php short tag by a normal one.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace Mafikes\KiwiApi;
 


### PR DESCRIPTION
I think this is the only one file that have this kind of deprecated php open tag in this whole repo. I have to change it to be able to try this package.